### PR TITLE
Allow if

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,37 @@ validate(post).then(errors => {
 });
 ```
 
+If you would want a property conditionally whitelisted you can use the @AllowIf decorator:
+
+```typescript
+import {validate, Allow, AllowIf, Min} from "class-validator";
+
+export class Post {
+
+    @Allow()
+    title: string;
+
+    @Min(0)
+    views: number;
+
+    @AllowIf(post => post.views > 10)
+    whitelistedProperty: number;
+}
+
+let post = new Post();
+post.title = 'Hello world!';
+post.views = 420;
+
+post.whitelistedProperty = 69;
+(post as any).nonWhitelistedProperty = "something";
+
+validate(post).then(errors => {
+  // post.whitelistedProperty is defined
+  // (post as any).nonWhitelistedProperty is not defined
+  ...
+});
+```
+
 If you would rather to have an error thrown when any non-whitelisted properties are present, pass another flag to
 `validate` method:
 

--- a/src/decorator/common/AllowIf.ts
+++ b/src/decorator/common/AllowIf.ts
@@ -7,13 +7,16 @@ import { getMetadataStorage } from '../../metadata/MetadataStorage';
 /**
  * If object has both allowed and not allowed properties a validation error will be thrown.
  */
-export function Allow(validationOptions?: ValidationOptions): PropertyDecorator {
+export function AllowIf(
+  condition: (object: any) => boolean,
+  validationOptions?: ValidationOptions
+): PropertyDecorator {
   return function (object: object, propertyName: string): void {
     const args: ValidationMetadataArgs = {
       type: ValidationTypes.WHITELIST,
       target: object.constructor,
       propertyName: propertyName,
-      constraints: [],
+      constraints: [condition],
       validationOptions: validationOptions,
     };
     getMetadataStorage().addValidationMetadata(new ValidationMetadata(args));

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -7,6 +7,7 @@
 // -------------------------------------------------------------------------
 
 export * from './common/Allow';
+export * from './common/AllowIf';
 export * from './common/IsDefined';
 export * from './common/IsOptional';
 export * from './common/Validate';

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -124,9 +124,18 @@ export class ValidationExecutor {
     const notAllowedProperties: string[] = [];
 
     Object.keys(object).forEach(propertyName => {
+      const metadatas = groupedMetadatas[propertyName];
       // does this property have no metadata?
-      if (!groupedMetadatas[propertyName] || groupedMetadatas[propertyName].length === 0)
+      if (!metadatas || metadatas.length === 0) {
         notAllowedProperties.push(propertyName);
+        return;
+      }
+      // does this property has condition to allow?
+      const conditionalWhitelistMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.WHITELIST && metadata.constraints.length > 0);
+      const canAllow = this.conditionalWhitelist(object, conditionalWhitelistMetadatas);
+      if (!canAllow) {
+        notAllowedProperties.push(propertyName);
+      }
     });
 
     if (notAllowedProperties.length > 0) {
@@ -240,6 +249,12 @@ export class ValidationExecutor {
     validationError.constraints = {};
 
     return validationError;
+  }
+
+  private conditionalWhitelist(object: object, metadatas: ValidationMetadata[]): ValidationMetadata[] {
+    return metadatas
+      .map(metadata => metadata.constraints[0](object))
+      .reduce((resultA, resultB) => resultA && resultB, true);
   }
 
   private conditionalValidations(object: object, value: any, metadatas: ValidationMetadata[]): ValidationMetadata[] {

--- a/test/functional/whitelist-validation.spec.ts
+++ b/test/functional/whitelist-validation.spec.ts
@@ -1,4 +1,4 @@
-import { Allow, IsDefined, IsOptional, Min } from '../../src/decorator/decorators';
+import { Allow, AllowIf, IsDefined, IsOptional, Min } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 import { ValidationTypes } from '../../src';
 
@@ -30,6 +30,42 @@ describe('whitelist validation', () => {
   it('should be able to whitelist with @Allow', () => {
     class MyClass {
       @Allow()
+      views: number;
+    }
+
+    const model: any = new MyClass();
+
+    model.views = 420;
+    model.unallowedProperty = 'non-whitelisted';
+
+    return validator.validate(model, { whitelist: true }).then(errors => {
+      expect(errors.length).toEqual(0);
+      expect(model.unallowedProperty).toBeUndefined();
+      expect(model.views).toEqual(420);
+    });
+  });
+
+  it("should'n be able to whitelist with @AllowIf when condition return false", () => {
+    class MyClass {
+      @AllowIf(o => false)
+      views: number;
+    }
+
+    const model: any = new MyClass();
+
+    model.views = 420;
+    model.unallowedProperty = 'non-whitelisted';
+
+    return validator.validate(model, { whitelist: true }).then(errors => {
+      expect(errors.length).toEqual(0);
+      expect(model.unallowedProperty).toBeUndefined();
+      expect(model.views).toBeUndefined();
+    });
+  });
+
+  it('should be able to whitelist with @AllowIf when condition return true', () => {
+    class MyClass {
+      @AllowIf(o => true)
       views: number;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is currently no way to define whether a property is conditionally whitelisted, for example:
```typescript
enum TypesCancel = {
  USER: 'user',
  STOCKOUT: 'stockout',
  OTHERS: 'others',
}

class CancelDTO {
  @IsEnum(TypesCancel)
  @IsNotEmpty() 
  type: TypesCancel;

  // if the type === TypesCancel.OTHERS, reason is required, but if not, must not sent
  @Optional() // with optional, it still receives even if the type !== TypesCancel.OTHERS
  @IsString()
  reason?: string;
}

const cancel = new CancelDTO();
cancel.type = TypesCancel.USER;
cancel.reason = 'reason';

validate(cancel).then(errors => {
  // cancel.reason is defined
});
```
Issue Number: https://github.com/typestack/class-validator/issues/1489
## What is the new behavior?
```typescript
enum TypesCancel = {
  USER: 'user',
  STOCKOUT: 'stockout',
  OTHERS: 'others',
}

class CancelDTO {
  @IsEnum(TypesCancel)
  @IsNotEmpty() 
  type: TypesCancel;

  @AllowIf(cancel => cancel.type === TypesCancel.OTHERS) // with AllowIf, the reason was accept if type === TypesCancel.OTHERS
  @IsString()
  reason?: string;
}

const cancel = new CancelDTO();
cancel.type = TypesCancel.USER;
cancel.reason = 'reason';

validate(cancel).then(errors => {
  // errors = reason should not exist
  // cancel.reason is not defined
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
